### PR TITLE
Added the participant base URL to the CDE environment

### DIFF
--- a/participant-template/cde/docker-compose.yml
+++ b/participant-template/cde/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       CDE_INFLUXDB_ORG: ${CDE_INFLUXDB_ORG}
       CDE_INFLUXDB_BUCKET: ${CDE_INFLUXDB_BUCKET}
       CDE_FUSEKI_URL: http://fuseki:3030
+      PARTICIPANT_BASE_URL: ${PARTICIPANT_NAME}.${DOMAIN_NAME}
     depends_on:
       influxdb:
         condition: service_healthy


### PR DESCRIPTION
Passing the PARTICIPANT_NAME.DOMAIN_NAME env variables to the CDE environment to create the https://<PARTICIPANT_NAME>.<DOMAIN_NAME>/protocol URL, to be used to actually pull the data.